### PR TITLE
handle singleAddress Hyphen alternate housenums

### DIFF
--- a/munge.R
+++ b/munge.R
@@ -169,7 +169,12 @@ pad <- pad %>%
         }
 
         if (x['rowType'] == 'singleAddress') {
-          return(singleAddress(x['lhnd']))
+          # if no hyphen, return lhnd, else return both lhnd and lhnd with the hyphen removed
+          if (grepl('-', x['lhnd'])) {
+            noHyphenlhnd <- gsub("-", "", x['lhnd'])
+            return(paste(x['lhnd'], noHyphenlhnd, sep=','))
+          }
+          return(x['lhnd'])
         }
 
         if (x['rowType'] == 'numericType') {


### PR DESCRIPTION
#22 Handles hyphenated addresses that do no have a range. Hyphenated addresses now have their house nums duplicated and show up as 51-02 and also 5102 41st avenue. 