### PR TITLE
adding github actions to make updates easier

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push]
+jobs:
+  skip:
+    name: Build and test
+    runs-on: ubuntu-latest
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - run: echo "${{ github.event.head_commit.message }}"
+  build:
+    needs: skip
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build docker image
+      run: |
+        docker build --tag pad-normalize .
+    - name: Munge data!
+      run: |
+        export $(echo '${{ github.event.head_commit.message }}' | sed 's/#.*//g' | xargs)
+        docker run -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize $VERSION

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,8 @@ jobs:
       run: |
         export $(echo '${{ github.event.head_commit.message }}' | sed 's/#.*//g' | xargs)
         docker run -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize $VERSION
+    - name: Upload the artifacts!
+      uses: actions/upload-artifact@v1
+      with:
+        name: output
+        path: data

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
     - name: Upload the artifacts!
       uses: actions/upload-artifact@v1
       with:
-        name: output
-        path: data
+        name: nycpad
+        path: data/nycpad

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,13 @@ on: [push]
 jobs:
   skip:
     name: Build and test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: "! contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - run: echo "${{ github.event.head_commit.message }}"
   build:
     needs: skip
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build docker image
@@ -19,8 +19,13 @@ jobs:
       run: |
         export $(echo '${{ github.event.head_commit.message }}' | sed 's/#.*//g' | xargs)
         docker run -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize $VERSION
-    - name: Upload the artifacts!
+    - name: Upload normalized pad!
       uses: actions/upload-artifact@v1
       with:
         name: nycpad
         path: data/nycpad
+    - name: Upload pad-checks!
+      uses: actions/upload-artifact@v1
+      with:
+        name: pad-checks
+        path: data/pad-checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,13 @@ on: [push]
 jobs:
   skip:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: "! contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - run: echo "${{ github.event.head_commit.message }}"
   build:
     needs: skip
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2
     - name: Build docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN mkdir -p /data/nycpad
 COPY . /usr/local/src/scripts
 
 WORKDIR /usr/local/src/scripts
+
+ENTRYPOINT ["./bin/normalize"]

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ or in detached mode:
 ```
 docker run -v $(pwd)/data:/usr/local/src/scripts/data -d pad-normalize 20a
 ```
+# How to run in Github Actions
+```
+git add .
+git commit -m 'VERSION=20a'
+git push origin master
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To "deploy" data as the source for the geosearch importer, run `npm run deploy`.
 
 For a new version of pad, two references to files need to be updated.  In `download_data` ensure that the download link points to the latest PAD version (17D, 18A, etc) and `load_data` make sure the path to the street name dictionary (snd17Dcow.txt, snd18Acow.txt, etc) reflects the current release.
 
-# How to run
+# How to run locally
 Make sure R is installed on your machine. If you just want CLI stuff:
 ```sh
 $ brew install R
@@ -43,4 +43,17 @@ Due to the nature of the PAD dataset, it is very likely that some data processin
 If you're happy with your data, push it to digital ocean using the included shell script:
 ```sh
 $ ./push-to-bucket.sh
+```
+# How to run if you have Docker installed
+1. Make sure you check the Bytes of Big Apple for the latest version of PAD (replace 20a with the latest version)
+```
+docker build --tag pad-normalize .
+```
+2. Once the build is complete
+```
+docker run -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize 20a
+```
+or in detached mode:
+```
+docker run -v $(pwd)/data:/usr/local/src/scripts/data -d pad-normalize 20a
 ```

--- a/_download_data.R
+++ b/_download_data.R
@@ -19,8 +19,7 @@ bblcentroids <- paste("https://planninglabs.carto.com/api/v2/sql?q=", URLencode(
 download(bblcentroids, dest=paste0(dataDir, "/bblcentroids.csv"), mode="wb")
 
 # Define source URL for downloading building footprints data (BIN centroids)
-bincentroids <- "https://data.cityofnewyork.us/api/views/r94s-f34j/rows.csv?accessType=DOWNLOAD"
+bincentroids <- "https://data.cityofnewyork.us/api/views/a6zb-fqrc/rows.csv?accessType=DOWNLOAD"
 
 # Download building footprints data
 download(bincentroids, dest=paste0(dataDir, "/bincentroids.csv"), mode="wb")
-

--- a/_download_data.R
+++ b/_download_data.R
@@ -18,8 +18,20 @@ bblcentroids <- paste("https://planninglabs.carto.com/api/v2/sql?q=", URLencode(
 # Download PLUTO data
 download(bblcentroids, dest=paste0(dataDir, "/bblcentroids.csv"), mode="wb")
 
+# Import the `httr` library for making HTTP requests
+library(httr)
+
+# Make a GET request on the building footprints' parent (and constant) ID
+r <- GET('https://data.cityofnewyork.us/api/views/nqwf-w8eh')
+
+# Define list of IDs belonging to all of the child views this dataset has
+ids <- strsplit(content(r)$metadata$geo$layers, ",")
+
+# Define the child view ID for BIN centroids
+view_id <- ids[[1]][length(ids[[1]])]
+
 # Define source URL for downloading building footprints data (BIN centroids)
-bincentroids <- "https://data.cityofnewyork.us/api/views/a6zb-fqrc/rows.csv?accessType=DOWNLOAD"
+bincentroids <- paste("https://data.cityofnewyork.us/api/views/", view_id, "/rows.csv?accessType=DOWNLOAD", sep="")
 
 # Download building footprints data
 download(bincentroids, dest=paste0(dataDir, "/bincentroids.csv"), mode="wb")

--- a/_globals.R
+++ b/_globals.R
@@ -9,4 +9,5 @@ if(length(args) == 0) {
 }
 
 dataDir <- "./data"
-outDir <-"/data/nycpad"
+outDir <-"./data/nycpad"
+checksDir <-"./data/pad-checks"

--- a/munge.R
+++ b/munge.R
@@ -59,6 +59,9 @@ checks$missing_zips %>% ifelse(., paste("✗ WARNING!", ., "MISSING ZIPCODES"), 
 checks$total_rows %>% paste("TOTAL ROWS:", .) %>% print
 checks$distinct_rows %>% paste("DISTINCT ROWS:",.) %>% print
 
+rm(pad)
+rm(snd)
+
 "WRITING" %>% print
 dir.create(outDir, showWarnings=FALSE)
 write_csv(expanded, paste0(outDir, '/labs-geosearch-pad-normalized.csv'), na="")

--- a/munge.R
+++ b/munge.R
@@ -66,6 +66,7 @@ gc()
 
 "WRITING" %>% print
 dir.create(outDir, showWarnings=FALSE)
+dir.create(checksDir, showWarnings=FALSE)
 write_csv(expanded, paste0(outDir, '/labs-geosearch-pad-normalized.csv'), na="")
 gc() 
 write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.1), ], paste0(outDir, '/labs-geosearch-pad-normalized-sample-lg.csv'), na="")
@@ -74,5 +75,5 @@ write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.05), ], paste0(outD
 gc() 
 write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.01), ], paste0(outDir, '/labs-geosearch-pad-normalized-sample-sm.csv'), na="")
 gc() 
-write(toJSON(checks), paste0(dataDir, '/labs-geosearch-pad-checks-', print(as.integer(Sys.time())*1000, digits=15), '.json'))
-gc() 
+write(toJSON(checks), paste0(checksDir, '/labs-geosearch-pad-checks-', print(as.integer(Sys.time())*1000, digits=15), '.json'))
+gc()

--- a/munge.R
+++ b/munge.R
@@ -18,6 +18,9 @@ pad %>% distinct(typeof(houseNums)) %>% print
 # It then does any other unnests.
 # Two unnests are performed here: first, the interpolations, then an unnest for the LGC join keys
 # After the latter joinkey is created, it performs an inner_join.
+# Using unnest_legacy to improve performance
+
+unnest <- unnest_legacy
 expanded <- pad %>% 
   mutate(houseNum = strsplit(houseNums, ',')) %>%
   unnest(houseNum) %>% 

--- a/munge.R
+++ b/munge.R
@@ -27,16 +27,17 @@ expanded <- pad %>%
   mutate(lgc = strsplit(gsub("(.{2})", "\\1,", validlgcs), ',')) %>% 
   unnest(lgc) %>%
   inner_join(snd, by=c('boro', 'sc5', 'lgc'))
-
+gc() 
 # Debugging messages about type distribution
 pad %>% group_by(rowType) %>% summarise(count = length(rowType)) %>% print
 expanded %>% group_by(rowType) %>% summarise(count = length(rowType)) %>% print
-
+gc() 
 "SELECTING RELEVANT COLUMNS FOR EXPORT" %>% print
 # Simply selects only needed columns in the output.
 expanded <- expanded %>%
   select(pad_bbl = bbl, houseNum, pad_bin = bin, pad_orig_stname = stname, pad_low = lhnd, pad_high = hhnd, pad_geomtype, stname = alt_st_name, zipcode, lng, lat) %>%
   filter(!is.na(lat) & !is.na(lng)) 
+gc() 
 # Checks:
 # 1. theoretical unnest count matches actual row count
 # 2. check for NAs in crucial columns (stname, lat, lng, bbl)
@@ -50,7 +51,7 @@ checks <- list(
   total_rows = expanded %>% nrow,
   distinct_rows = expanded %>% distinct %>% nrow
 )
-
+gc() 
 checks$missing_lats %>% ifelse(., paste("✗ WARNING!", ., "MISSING LATITUDES"), "✓ LATITUDES") %>% print
 checks$missing_lngs %>% ifelse(., paste("✗ WARNING!", ., "MISSING LONGITUDES"), "✓ LONGITUDES") %>% print
 checks$missing_bbls %>% ifelse(., paste("✗ WARNING!", ., "MISSING BBLS"), "✓ BBLS") %>% print
@@ -61,11 +62,17 @@ checks$distinct_rows %>% paste("DISTINCT ROWS:",.) %>% print
 
 rm(pad)
 rm(snd)
+gc()
 
 "WRITING" %>% print
 dir.create(outDir, showWarnings=FALSE)
 write_csv(expanded, paste0(outDir, '/labs-geosearch-pad-normalized.csv'), na="")
+gc() 
 write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.1), ], paste0(outDir, '/labs-geosearch-pad-normalized-sample-lg.csv'), na="")
+gc() 
 write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.05), ], paste0(outDir, '/labs-geosearch-pad-normalized-sample-md.csv'), na="")
+gc() 
 write_csv(expanded[sample(nrow(expanded), nrow(expanded) * 0.01), ], paste0(outDir, '/labs-geosearch-pad-normalized-sample-sm.csv'), na="")
+gc() 
 write(toJSON(checks), paste0(dataDir, '/labs-geosearch-pad-checks-', print(as.integer(Sys.time())*1000, digits=15), '.json'))
+gc() 


### PR DESCRIPTION
- adding `entrypoint` in dockerfile
- using `unnest-legacy` instead of `unnest` to improve speed (total build time is around 10 min)
- updating NYC opendata url for bin centroid (the old one doesn't work anymore) 
- adding garbage collection to avoid out of memory issues
- dumping qaqc checks to a different directory `pad-checks` (this can be later removed once we start dumping to s3)
- adding github actions workflow (currently dumping output files to artifacts, we can work on dumping to s3 in the future)
