### PR TITLE
Fix sequencing bug by enforcing "from -> to" numeric order

### DIFF
--- a/_functions.R
+++ b/_functions.R
@@ -15,7 +15,9 @@ delegate <- cmpfun(function(x) {
   }
   
   if (x['rowType'] == 'numericType') {
-    return(numericType(x['lhns_lhyphen_i'], x['hhns_lhyphen_i']))
+    from <- min(x['lhns_lhyphen_i'], x['hhns_lhyphen_i'])
+    to <- max(x['lhns_lhyphen_i'], x['hhns_lhyphen_i'])
+    return(numericType(from, to))
   }
   
   if (x['rowType'] == 'hyphenNoSuffix') {


### PR DESCRIPTION
## issue: NYCPlanning/labs-geosearch-docker#47
based on the error, it seems like in pad 20d, it's not always the case that `lhns_lhyphen_i` < `hhns_lhyphen_i`, which led to the error in `seq(from, to, 2)` in the numerictype function (if by=2 is positive, then from has to be numerically smaller than to). This could be a source data error. 

this PR fixes the bug, but we would still have to figure out why we have cases where`lhns_lhyphen_i` < `hhns_lhyphen_i`