### PR TITLE
Increase timeout to 10 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 on: 
   push:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
-on: [push]
+on: 
+  push:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    if: "contains(github.event.head_commit.message, '[build]')"
     env:
       AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -38,6 +38,7 @@ jobs:
           -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize $VERSION
     
     - name: Complete and Upload!
+      if: github.ref == 'refs/heads/main'
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: ./push-to-bucket.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/tidyverse:latest
+FROM rocker/tidyverse:3.6.3
 
 RUN install2.r --error \
     --deps TRUE \

--- a/README.md
+++ b/README.md
@@ -61,10 +61,5 @@ docker run -v $(pwd)/data:/usr/local/src/scripts/data -d pad-normalize 20d
 ```
 # How to run in Github Actions
 Github actions will pick up the version of pad from `version.env`, so please remember to update the pad version in this file before commit
-```
-git add .
-git commit -m '[build]'
-git push origin master
-```
-> github actions will look at the commit message and only trigger a workflow if `[build]` is mentioned.
+> github actions will run on all branches, and only deploy computed files to digitocean when pushing to the `main` branch
 

--- a/_download_data.R
+++ b/_download_data.R
@@ -1,3 +1,5 @@
+# Increase timeout to 600 -> 10 min
+options(timeout=600)
 # Define location of specified PAD version
 source <- paste("https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/pad", padVersion, ".zip", sep="")
 # Download PAD


### PR DESCRIPTION
1. currently building footprints takes forever to download from socrata, increasing timeout
2. fixing docker image version for rocker/tidyverse
3. allow runs to happen to pushes to all branches, and only deploy computed files to digitalocean spaces if it's on the main branch 