### PR TITLE
More csv importer migration cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: set version
+    - name: Set version
       id: version
       shell: bash
       run: |
@@ -20,7 +20,7 @@ jobs:
         echo "$VERSION"
         echo ::set-output name=version::$VERSION
 
-    - name: install minio
+    - name: Install Minio
       run: |
         curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
         sudo chmod +x mc
@@ -31,14 +31,14 @@ jobs:
       run: |
         docker build --tag pad-normalize .
 
-    - name: Munge data!
+    - name: Build dataset!
       env:
         VERSION: ${{ steps.version.outputs.version }}
       run: |
         docker run --user $(id -u):$(id -g) \
           -v $(pwd)/data:/usr/local/src/scripts/data pad-normalize $VERSION
     
-    - name: Complete and Upload!
+    - name: Upload!
       if: github.ref == 'refs/heads/main'
       env:
         VERSION: ${{ steps.version.outputs.version }}

--- a/_prepare.R
+++ b/_prepare.R
@@ -3,7 +3,7 @@
 # https://github.com/pelias/csv-importer#custom-data
 "ADDING CSV-IMPORTER COLUMNS" %>% print
 expanded <- expanded %>% 
-  mutate(addendum_json_pad = paste('{"bbl":"', bbl, '","bin":"',bin,'"}', sep = "")) %>%
+  mutate(addendum_json_pad = paste('{"bbl":"', bbl, '","bin":"',bin,'","version":"',padVersion,'"}', sep = "")) %>%
   mutate(
     name = case_when(
       is.na(houseNum) ~ alt_st_name,

--- a/push-to-bucket.sh
+++ b/push-to-bucket.sh
@@ -11,17 +11,13 @@ function upload {
     cd data/nycpad
     sudo chown $USER:$USER *.csv
 
-    zip labs-geosearch-pad-normalized.zip labs-geosearch-pad-normalized.csv 
-    upload labs-geosearch-pad-normalized.zip
+    upload labs-geosearch-pad-normalized.csv
 
-    zip labs-geosearch-pad-normalized-sample-lg.zip labs-geosearch-pad-normalized-sample-lg.csv
-    upload labs-geosearch-pad-normalized-sample-lg.zip
+    upload labs-geosearch-pad-normalized-sample-lg.csv
 
-    zip labs-geosearch-pad-normalized-sample-md.zip labs-geosearch-pad-normalized-sample-md.csv
-    upload labs-geosearch-pad-normalized-sample-md.zip
+    upload labs-geosearch-pad-normalized-sample-md.csv
 
-    zip labs-geosearch-pad-normalized-sample-sm.zip labs-geosearch-pad-normalized-sample-sm.csv
-    upload labs-geosearch-pad-normalized-sample-sm.zip
+    upload labs-geosearch-pad-normalized-sample-sm.csv
 )
 
 echo "done"


### PR DESCRIPTION
## Summary

This PR:
* Adds `version` to the `addendum_json_pad` json so that version of PAD used to generate the data is included in Geosearch JSON responses
* Updates `push-to-bucket.sh` to upload unzipped CSVs to DO because that is what Pelias' built in `csv-importer` expects
* Minor GH action cleanup