### PR TITLE
Add line to dockerfile to point image to use cran repo for dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rocker/tidyverse:3.6.3
 
+RUN echo "options(repos = c(CRAN = 'https://cran.rstudio.org'))" >> /usr/local/lib/R/etc/Rprofile.site
+
 RUN install2.r --error \
     --deps TRUE \
     jsonlite \


### PR DESCRIPTION
This PR adds a line to `Dockerfile` to address [an error that came up while running the GH action `build`.](https://github.com/NYCPlanning/labs-geosearch-pad-normalize/actions/runs/5742055468/job/15563389473#step:5:55)

The error suggests that the Dockerfile is trying to install r packages from `mran.microsoft.com` but couldn't reach that host. Some googling led me to this [Issue on the repo for the base docker image we're using](https://github.com/rocker-org/rocker-versioned/issues/102). It seems the mran host is unreliable so adding this change should point the docker image at cran.studio.org for package downloads, which is hopefully more stable.